### PR TITLE
Update textcat.py to avoid dropping records in `into_hf_format()`

### DIFF
--- a/prodigy_hf/textcat.py
+++ b/prodigy_hf/textcat.py
@@ -43,7 +43,7 @@ def into_hf_format(train_examples: List[Dict], valid_examples: List[Dict], varia
             if (variant == "multi") and ex['accept']:
                 # It could be that the dataset was accepted but didn't have anything selected. 
                 label = label2id[ex["accept"][0]]
-            if label: 
+            if label is not None: 
                 yield {
                     "text": ex["text"],
                     "label": label

--- a/tests/test_train_basics.py
+++ b/tests/test_train_basics.py
@@ -31,6 +31,10 @@ def test_smoke_textcat(dataset, tmpdir):
     with pytest.raises(ValueError):
         hf_train_textcat("does-not-exist", tmpdir, epochs=1, model_name="hf-internal-testing/tiny-random-DistilBertModel")
     
+    import os
+    for item in os.listdir(tmpdir):
+        item_path = os.path.join(tmpdir, item)
+        print(item_path)
     # Catch models trained on binary data. We don't support these because the only
     # possible labels are "ACCEPT" and "REJECT" and we don't have access to the original label.
     if "binary" in dataset:

--- a/tests/test_train_basics.py
+++ b/tests/test_train_basics.py
@@ -31,17 +31,13 @@ def test_smoke_textcat(dataset, tmpdir):
     with pytest.raises(ValueError):
         hf_train_textcat("does-not-exist", tmpdir, epochs=1, model_name="hf-internal-testing/tiny-random-DistilBertModel")
     
-    import os
-    for item in os.listdir(tmpdir):
-        item_path = os.path.join(tmpdir, item)
-        print(item_path)
     # Catch models trained on binary data. We don't support these because the only
     # possible labels are "ACCEPT" and "REJECT" and we don't have access to the original label.
     if "binary" in dataset:
         with pytest.raises(SystemExit):
-            prodigy_dict = hf_textcat_correct("xxx", f"{tmpdir}/checkpoint-2", "dataset:fashion")
+            prodigy_dict = hf_textcat_correct("xxx", f"{tmpdir}/checkpoint-3", "dataset:fashion")
     else:
         # The multi-scenario is fine, because the labels carry the actual name
-        prodigy_dict = hf_textcat_correct("xxx", f"{tmpdir}/checkpoint-2", "dataset:fashion")
+        prodigy_dict = hf_textcat_correct("xxx", f"{tmpdir}/checkpoint-3", "dataset:fashion")
         for ex in prodigy_dict['stream']:
             assert set([lab['id'] for lab in ex['options']]) == set(["foo", "bar", "buz"])


### PR DESCRIPTION
Found bug in `into_hf_format` in `textcat.py`.

Currently, `into_hf_format` only keeps whatever labels have `id = 1` when `variant = 'multi'` as step before runs
```
label = label2id[ex["accept"][0]]
```

This step maps the labels to integers as required by HF. 

However, only includes the records in the generator when `label = 1` as the current code yields:
```
            if label: 
                yield {
                    "text": ex["text"],
                    "label": label
                }
```

The current behavior will drop examples where label is not `1`.

This fix changes so that any records where `label is not None` are yielded.